### PR TITLE
feat: enable email tags to be loaded to mongo

### DIFF
--- a/src/apis/v1/notification.js
+++ b/src/apis/v1/notification.js
@@ -10,10 +10,12 @@ module.exports = require('express').Router()
         let to = req.query.to
         let subject = req.query.subject
         let content = req.body
-
+        // Extract tags from request url params
+        let tags = req.query.tags
+        
         let info = await emailSender.trySendWithFallback(from, to, subject, content)
-        await db.notifyingLog.logEmailNotifying(null, from, to, subject, content)
-
+        // Load event to audit DB
+        await db.notifyingLog.logEmailNotifying(null, from, to, subject, content, tags)
         log.info('Email message sent, id: %s', info.messageId)
         res.send(info)
     })

--- a/src/db/notification_audit_log.js
+++ b/src/db/notification_audit_log.js
@@ -46,12 +46,13 @@ module.exports.countNotifying = count
 
 
 // For Email
-module.exports.logEmailNotifying = async (userId, from, to, subject, content) => {
+module.exports.logEmailNotifying = async (userId, from, to, subject, content, tags) => {
     return await log(userId, 'email', {
         from: from,
         to: to,
         subject: subject,
-        content: content
+        content: content,
+        tags: tags
     })
 }
 


### PR DESCRIPTION
- Extract tags passed as parameter in the post request url
- Pass to `db.notifyingLog.logEmailNotifying()`
- Function loads tags to db in raw form